### PR TITLE
feat: exit on server error

### DIFF
--- a/src/core/TestRunner.ts
+++ b/src/core/TestRunner.ts
@@ -66,20 +66,25 @@ export class TestRunner {
 
     terminalLogger.start(this.serverAddress);
 
+    try {
+      await this.config.server.start({
+        config: this.config,
+        sessions: this.manager.sessions,
+        onSessionStarted: this.onSessionStarted,
+        onSessionFinished: this.onSessionFinished,
+        onRerunSessions: this.onRerunSessions,
+      });
+    } catch (e) {
+      console.log('Something went wrong while trying to start the server.\n\n', e);
+      process.exit(1);
+    }
+
     this.updateTestProgressIntervalId = setInterval(() => {
       this.updateTestProgress();
     }, 500);
     this.updateTestProgress();
 
     const sessionsArray = Array.from(this.manager.sessions.values());
-    await this.config.server.start({
-      config: this.config,
-      sessions: this.manager.sessions,
-      onSessionStarted: this.onSessionStarted,
-      onSessionFinished: this.onSessionFinished,
-      onRerunSessions: this.onRerunSessions,
-    });
-
     const testRun = this.createTestRun(sessionsArray);
     this.runTests(testRun);
   }


### PR DESCRIPTION
closes https://github.com/LarsDenBakker/web-test-runner/issues/30

<img width="679" alt="Screenshot 2020-05-27 at 19 04 58" src="https://user-images.githubusercontent.com/17054057/83051372-3c6ea980-a04e-11ea-9409-ee12fbf476a3.png">

I moved the `updateTestProgress` to below starting the server, because otherwise you'd get this:

![image](https://user-images.githubusercontent.com/17054057/83051330-2d87f700-a04e-11ea-8ded-df12bd605a91.png)
